### PR TITLE
feat: add auto-label workflow for new issues

### DIFF
--- a/.github/workflows/minteku-auto-label.yml
+++ b/.github/workflows/minteku-auto-label.yml
@@ -1,0 +1,21 @@
+name: Auto Label Issues with MINTEKU
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    
+    steps:
+      - name: Add MINTEKU label to new issue
+        run: |
+          ISSUE_NUM=${{ github.event.issue.number }}
+          LABEL_NAME="MINTEKU-${ISSUE_NUM}"
+          
+          gh issue edit $ISSUE_NUM --add-label "$LABEL_NAME"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GitHub Action to automatically label new issues with MINTEKU-<issue_number>
- This enables the existing MINTEKU automation workflow to trigger automatically

## Test plan
- [ ] Create a new issue and verify it gets labeled with MINTEKU-<issue_number>
- [ ] Verify the existing minteku-automation.yml workflow triggers after labeling

🤖 Generated with [Claude Code](https://claude.ai/code)